### PR TITLE
Support for cjs files

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ joycon.load(['package-lock.json', 'yarn.lock'])
 })
 ```
 
-By default only `.js` and `.json` file are parsed, otherwise raw data will be returned, so you can add custom loader to parse them:
+By default only `.js`, `.cjs`, and `.json` file are parsed, otherwise raw data will be returned, so you can add custom loader to parse them:
 
 ```js
 const joycon = new JoyCon()

--- a/lib/index.js
+++ b/lib/index.js
@@ -158,7 +158,7 @@ class JoyCon {
         loadSync: filepath => {
           const extname = _path.default.extname(filepath).slice(1);
 
-          if (extname === 'js') {
+          if (extname === 'js' || extname === 'cjs') {
             delete require.cache[filepath];
             return require(filepath);
           }
@@ -204,7 +204,7 @@ class JoyCon {
         loadSync: filepath => {
           const extname = _path.default.extname(filepath).slice(1);
 
-          if (extname === 'js') {
+          if (extname === 'js' || extname === 'cjs') {
             delete require.cache[filepath];
             return require(filepath);
           }

--- a/src/index.js
+++ b/src/index.js
@@ -152,7 +152,7 @@ export default class JoyCon {
         test: /\.+/,
         loadSync: (filepath) => {
           const extname = path.extname(filepath).slice(1)
-          if (extname === 'js') {
+          if (extname === 'js' || extname === 'cjs') {
             delete require.cache[filepath]
             return require(filepath)
           }


### PR DESCRIPTION
cjs files are just commonjs style js files, so this just makes sure joycon treats them the same.

Could probably add support for mjs files as well, but that is more complicated (would need to `await import()` in a sync function).