### PR TITLE
fix: just parse the contents as json by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ joycon.load(['package-lock.json', 'yarn.lock'])
 })
 ```
 
-By default only `.js`, `.cjs`, and `.json` file are parsed, otherwise raw data will be returned, so you can add custom loader to parse them:
+By default non-js files are parsed as JSON, if you want something different you can add a loader:
 
 ```js
 const joycon = new JoyCon()

--- a/src/index.js
+++ b/src/index.js
@@ -157,19 +157,12 @@ export default class JoyCon {
             return require(filepath)
           }
 
-          if (extname === 'json') {
-            if (this.packageJsonCache.has(filepath)) {
-              return this.packageJsonCache.get(filepath)[options.packageKey]
-            }
-
-            const data = this.options.parseJSON(readFileSync(filepath))
-            return data
+          if (this.packageJsonCache.has(filepath)) {
+            return this.packageJsonCache.get(filepath)[options.packageKey]
           }
 
-          // Don't parse data
-          // If it's neither .js nor .json
-          // Leave this to user-land
-          return readFileSync(filepath)
+          const data = this.options.parseJSON(readFileSync(filepath))
+          return data
         },
       }
       const loader = this.findLoader(filepath) || defaultLoader


### PR DESCRIPTION
really no point in returning raw text, if a user wants to parse non js/json content they will add a loader anyway